### PR TITLE
Fix piece display timing before CPU turn

### DIFF
--- a/chess.py
+++ b/chess.py
@@ -918,15 +918,15 @@ def run_chess_game():
     # ゲームループ
     running = True
     while running:
+        draw_game()  # まず盤面を描画してユーザー操作を反映
+        pygame.display.flip()
+
         # AI: CPUのターン処理
         if not game.game_over and game.turn == 'b':
             pygame.time.wait(1000)
             game.cpu_play_turn()
             selected = None
             selected_empty_square = None
-
-        draw_game() # 描画関数を呼び出し
-        pygame.display.flip()
 
         for event in pygame.event.get():
             if event.type == pygame.QUIT:


### PR DESCRIPTION
## Summary
- update game loop so the board redraws before CPU waiting logic

## Testing
- `python -m py_compile chess.py`


------
https://chatgpt.com/codex/tasks/task_e_6840684b145c832998ee1b35c97d32b7