### PR TITLE
Implement money UI move and gacha odds

### DIFF
--- a/chess.py
+++ b/chess.py
@@ -874,8 +874,14 @@ def run_chess_game():
     dog_image_pos_y = HEIGHT - game.dog_image_display_size[1] - 20 # 下端から20px
     dog_image_display_rect = pygame.Rect(500, 110, 10, 60)
 
-    # 所持金表示エリア
-    money_bg_rect = pygame.Rect(UI_AREA_START_X + 200, HEIGHT - 90, WIDTH - UI_AREA_START_X - 210, 80)
+    # 所持金表示エリア (画面右下に配置)
+    MONEY_RECT_SIZE = (240, 80)
+    money_bg_rect = pygame.Rect(
+        WIDTH - MONEY_RECT_SIZE[0] - 20,
+        HEIGHT - MONEY_RECT_SIZE[1] - 20,
+        MONEY_RECT_SIZE[0],
+        MONEY_RECT_SIZE[1],
+    )
 
 
     # ボタン配置


### PR DESCRIPTION
## Summary
- reposition money display to the bottom-right of the screen
- keep gacha probability UI next to each purchase button

## Testing
- `python -m py_compile chess.py`

------
https://chatgpt.com/codex/tasks/task_e_68411668909c8329a47d766fa7bfac29